### PR TITLE
update to the non-deprecated constants

### DIFF
--- a/custom_components/aten_pe/sensor.py
+++ b/custom_components/aten_pe/sensor.py
@@ -11,10 +11,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ELECTRIC_CURRENT_AMPERE,
-    ELECTRIC_POTENTIAL_VOLT,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_WATT,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -28,28 +28,28 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         key="outletCurrent",
         device_class=SensorDeviceClass.CURRENT,
         name="Current",
-        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="outletVoltage",
         device_class=SensorDeviceClass.VOLTAGE,
         name="Voltage",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="outletPower",
         device_class=SensorDeviceClass.POWER,
         name="Power",
-        native_unit_of_measurement=POWER_WATT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="outletPowerDissipation",
         device_class=SensorDeviceClass.ENERGY,
         name="Power Dissipation",
-        native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
home assistant 2025.1.0 finally deprecated the old constants causing this integration to fail

updated to use the new constants which have worked since [2022.11.0.b0](https://github.com/home-assistant/core/commit/8645e47b07fd2ab3386012fe492fa9ab690830b5)